### PR TITLE
Checkpoints clear

### DIFF
--- a/flowcraft/generator/templates/fastqc_trimmomatic.nf
+++ b/flowcraft/generator/templates/fastqc_trimmomatic.nf
@@ -15,6 +15,9 @@ if ( !params.trimMinLength{{ param_id }}.toString().isNumber() ){
 IN_trimmomatic_opts_{{ pid }} = Channel.value([params.trimSlidingWindow{{ param_id }},params.trimLeading{{ param_id }},params.trimTrailing{{ param_id }},params.trimMinLength{{ param_id }}])
 IN_adapters_{{ pid }} = Channel.value(params.adapters{{ param_id }})
 
+clear = params.clearAtCheckpoint ? "true" : "false"
+checkpointClear_{{ pid }} = Channel.value(clear)
+
 process fastqc_{{ pid }} {
 
     // Send POST request to platform
@@ -136,6 +139,7 @@ process trimmomatic_{{ pid }} {
     set sample_id, file(fastq_pair), trim_range, phred from MAIN_fastqc_trim_{{ pid }}.join(SIDE_phred_{{ pid }})
     val opts from IN_trimmomatic_opts_{{ pid }}
     val ad from IN_adapters_{{ pid }}
+    val clear from checkpointClear_{{ pid }}
 
     output:
     set sample_id, "${sample_id}_*trim.fastq.gz" into {{ output_channel }}

--- a/flowcraft/generator/templates/skesa.nf
+++ b/flowcraft/generator/templates/skesa.nf
@@ -1,4 +1,7 @@
 
+clear = params.clearAtCheckpoint ? "true" : "false"
+checkpointClear_{{ pid }} = Channel.value(clear)
+
 process skesa_{{ pid }} {
 
     // Send POST request to platform
@@ -9,6 +12,7 @@ process skesa_{{ pid }} {
 
     input:
     set sample_id, file(fastq_pair) from {{ input_channel }}
+    val clear from checkpointClear_{{ pid }}
 
     output:
     set sample_id, file('*.fasta') into {{ output_channel }}

--- a/flowcraft/generator/templates/spades.nf
+++ b/flowcraft/generator/templates/spades.nf
@@ -14,6 +14,9 @@ if ( params.spadesKmers{{ param_id }}.toString().split(" ").size() <= 1 ){
 }
 IN_spades_kmers_{{pid}} = Channel.value(params.spadesKmers{{ param_id }})
 
+clear = params.clearAtCheckpoint ? "true" : "false"
+checkpointClear_{{ pid }} = Channel.value(clear)
+
 process spades_{{ pid }} {
 
     // Send POST request to platform
@@ -26,6 +29,7 @@ process spades_{{ pid }} {
     set sample_id, file(fastq_pair), max_len from {{ input_channel }}.join(SIDE_max_len_{{ pid }})
     val opts from IN_spades_opts_{{ pid }}
     val kmers from IN_spades_kmers_{{ pid }}
+    val clear from checkpointClear_{{ pid }}
 
     output:
     set sample_id, file('*_spades*.fasta') into {{ output_channel }}

--- a/flowcraft/generator/templates/trimmomatic.nf
+++ b/flowcraft/generator/templates/trimmomatic.nf
@@ -15,6 +15,9 @@ if ( !params.trimMinLength{{ param_id}}.toString().isNumber() ){
 IN_trimmomatic_opts_{{ pid }} = Channel.value([params.trimSlidingWindow{{ param_id}},params.trimLeading{{ param_id}},params.trimTrailing{{ param_id}},params.trimMinLength{{ param_id}}])
 IN_adapters_{{ pid }} = Channel.value(params.adapters{{ param_id}})
 
+clear = params.clearAtCheckpoint ? "true" : "false"
+checkpointClear_{{ pid }} = Channel.value(clear)
+
 process trimmomatic_{{ pid }} {
 
     // Send POST request to platform
@@ -29,6 +32,7 @@ process trimmomatic_{{ pid }} {
     val trim_range from Channel.value("None")
     val opts from IN_trimmomatic_opts_{{ pid }}
     val ad from IN_adapters_{{ pid }}
+    val clear from checkpointClear_{{ pid }}
 
     output:
     set sample_id, "${sample_id}_*trim.fastq.gz" into {{ output_channel }}

--- a/flowcraft/nextflow.config
+++ b/flowcraft/nextflow.config
@@ -1,5 +1,20 @@
 params {
     platformHTTP = null
+
+    // Settings this option to true, will trigger the removal of temporary
+    // data (usually fastq reads) at particular checkpoint processes that
+    // modify that data. These checkpoint processes include 'trimmomatic',
+    // 'spades' and 'skesa'.
+    // WARNING: This will remove temporary fastq files that are not necessary
+    // for the completion of the pipeline but, consequently, will disable
+    // the resume functionality of the pipeline. However, it is often necessary
+    // for very large pipelines and whenever disk space is critical.
+    // More precisely, these checkpoint components will check whether the
+    // putative temporary files are inside the nextflow work directory by
+    // matching the regex: ".*/work/.{2}/.{30}/.*"
+    // If it is a match, then the file is assumed to be a temporary one and
+    // will be removed.
+    clearAtCheckpoint = false
 }
 
 env {

--- a/flowcraft/templates/trimmomatic.py
+++ b/flowcraft/templates/trimmomatic.py
@@ -23,6 +23,8 @@ The following variables are expected whether using NextFlow or the
     - e.g.: ``'[trim_sliding_window, trim_leading, trim_trailing, trim_min_length]'``
 - ``phred`` : List of guessed phred values for each sample
     - e.g.: ``'[SampleA: 33, SampleB: 33]'``
+- ``clear`` : If 'true', remove the input fastq files at the end of the
+    component run, IF THE FILES ARE IN THE WORK DIRECTORY
 
 Generated output
 ----------------
@@ -46,11 +48,12 @@ Code documentation
 # TODO: Add option to remove adapters
 # TODO: What to do when there is encoding failure
 
-__version__ = "1.0.2"
-__build__ = "28032018"
+__version__ = "1.0.3"
+__build__ = "20062018"
 __template__ = "trimmomatic-nf"
 
 import os
+import re
 import json
 import fileinput
 import subprocess
@@ -90,6 +93,7 @@ if __file__.endswith(".command.sh"):
     TRIM_OPTS = [x.strip() for x in '$opts'.strip("[]").split(",")]
     PHRED = '$phred'
     ADAPTERS_FILE = '$ad'
+    CLEAR = '$clear'
 
     logger.debug("Running {} with parameters:".format(
         os.path.basename(__file__)))
@@ -99,6 +103,7 @@ if __file__.endswith(".command.sh"):
     logger.debug("TRIM_OPTS: {}".format(TRIM_OPTS))
     logger.debug("PHRED: {}".format(PHRED))
     logger.debug("ADAPTERS_FILE: {}".format(ADAPTERS_FILE))
+    logger.debug("CLEAR: {}".format(CLEAR))
 
 TRIM_PATH = "/NGStools/Trimmomatic-0.36/trimmomatic.jar"
 ADAPTERS_PATH = "/NGStools/Trimmomatic-0.36/adapters"
@@ -230,7 +235,7 @@ def trimmomatic_log(log_file, sample_id):
     write_report(log_storage, "trimmomatic_report.csv", sample_id)
 
 
-def clean_up():
+def clean_up(fastq_pairs, clear):
     """Cleans the working directory of unwanted temporary files"""
 
     # Find unpaired fastq files
@@ -240,6 +245,14 @@ def clean_up():
     # Remove unpaired fastq files, if any
     for fpath in unpaired_fastq:
         os.remove(fpath)
+
+    if clear == "true":
+        for fq in fastq_pairs:
+            # Get real path of fastq files, following symlinks
+            rp = os.path.realpath(fq)
+            logger.debug("Removing temporary fastq file path: {}".format(rp))
+            if re.match(".*/work/.{2}/.{30}/.*", rp):
+                os.remove(rp)
 
 
 def merge_default_adapters():
@@ -264,7 +277,8 @@ def merge_default_adapters():
 
 
 @MainWrapper
-def main(sample_id, fastq_pair, trim_range, trim_opts, phred, adapters_file):
+def main(sample_id, fastq_pair, trim_range, trim_opts, phred, adapters_file,
+         clear):
     """ Main executor of the trimmomatic template.
 
     Parameters
@@ -284,6 +298,9 @@ def main(sample_id, fastq_pair, trim_range, trim_opts, phred, adapters_file):
     adapters_file : str
         Path to adapters file. If not provided, or the path is not available,
         it will use the default adapters from Trimmomatic will be used
+    clear : str
+        Can be either 'true' or 'false'. If 'true', the input fastq files will
+        be removed at the end of the run, IF they are in the working directory
     """
 
     logger.info("Starting trimmomatic")
@@ -372,7 +389,7 @@ def main(sample_id, fastq_pair, trim_range, trim_opts, phred, adapters_file):
 
     trimmomatic_log("{}_trimlog.txt".format(sample_id), sample_id)
 
-    clean_up()
+    clean_up(fastq_pair, clear)
 
     # Check if trimmomatic ran successfully. If not, write the error message
     # to the status channel and exit.
@@ -386,4 +403,5 @@ def main(sample_id, fastq_pair, trim_range, trim_opts, phred, adapters_file):
 
 if __name__ == '__main__':
 
-    main(SAMPLE_ID, FASTQ_PAIR, TRIM_RANGE, TRIM_OPTS, PHRED, ADAPTERS_FILE)
+    main(SAMPLE_ID, FASTQ_PAIR, TRIM_RANGE, TRIM_OPTS, PHRED, ADAPTERS_FILE,
+         CLEAR)


### PR DESCRIPTION
This PR introduces a new global parameter, `params.clearAtCheckpoint`, which can be freely used by any component that modifies its input. When set to true, components are allowed to remove the intermediate input files that are no longer used downstream of the pipeline. It is noteworthy, however, that input files are usually staged as symlinks and it is important not to remove files outside the work directory of nextflow. In python, the removal of a symlink following up to its source with a check for the presence of the work directory in the path can be done in the following way:

```
# Get real path of the symlink
rp = os.path.realpath(fq)
logger.debug("Removing temporary fastq file path: {}".format(rp))
# Remove only when the file is in the work directory
if re.match(".*/work/.{2}/.{30}/.*", rp):
    os.remove(rp)
```