### PR TITLE
added new component fasterq-dump to flowcraft

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,21 @@
 with failed processes but with the work directory removed (the log files
 where no longer available).
 
+### New components
+
+- Added new component called `fasterq_dump` that adds fasterq_dump from
+sra-tools.
+
+### Minor/Other changes
+
+- Added check for `params.accessions` that enables to report a proper
+error when it is set to `null`.
+
+### Bug fixes
+
+- Removed the need for the nf process templates to have an empty line
+at the beginning of the template files.
+
 ## 1.2.1
 
 ### Improvements

--- a/docs/user/available_components.rst
+++ b/docs/user/available_components.rst
@@ -14,6 +14,9 @@ Download
 - :doc:`components/reads_download`: Downloads reads from the SRA/ENA public
   databases from a list of accessions.
 
+- :doc:`components/fasterq_dump`: Downloads reads from the SRA public databases
+  from a list of accessions, using ``fasterq-dump``.
+
 Reads Quality Control
 --------------------
 

--- a/docs/user/components/fasterq_dump.rst
+++ b/docs/user/components/fasterq_dump.rst
@@ -16,8 +16,8 @@ receive FastQ data.
 Input/Output type
 ------------------
 
-- Input type: ``Accessions``
-- Output type: ``FastQ``
+- Input type: ``accessions``
+- Output type: ``fastq``
 
 .. note::
     The default input parameter for Accessions data is ``--accessions``.
@@ -25,8 +25,8 @@ Input/Output type
 Parameters
 ----------
 
-- ``option_file``: This options enables the *option-file* parameter to
-``fasterq-dump``, enabling to pass additional parameters to it.
+- ``option_file``: This options enables the *option-file* parameter of
+``fasterq-dump``, allowing parameters to be passed.
 - ``compress_fastq``: This options allows users to disable the compression of
 the fastq files resulting from this component. The default ('yes') behavior
 compresses the fastq files to *fastq.gz*.

--- a/docs/user/components/fasterq_dump.rst
+++ b/docs/user/components/fasterq_dump.rst
@@ -1,0 +1,47 @@
+fasterq_dump
+============
+
+Purpose
+-------
+
+This component downloads reads from the SRA public databases from a
+list of accessions. This component uses ``fasterq-dump`` from
+`NCBI sra-tools <https://github.com/ncbi/sra-tools>`_. ``fasterq-dump``
+increases the download speed in comparison from ``fastq-dump`` by
+**multi-threading** the extraction of FASTQ from SRA-accessions.
+The reads for each accession are then emitted through
+the main output of this component to any other component (or components) that
+receive FastQ data.
+
+Input/Output type
+------------------
+
+- Input type: ``Accessions``
+- Output type: ``FastQ``
+
+.. note::
+    The default input parameter for Accessions data is ``--accessions``.
+
+Parameters
+----------
+
+- ``option_file``: This options enables the `option-file` parameter to
+``fasterq-dump``, enabling to pass additional parameters to it.
+
+Published results
+-----------------
+
+- ``reads/<accession>``: Stores the reads for each provided accession.
+
+Published reports
+-----------------
+
+None.
+
+Default directives
+------------------
+
+- ``cpus``: 1
+- ``memory``: 1GB
+- ``container``: flowcraft/sra-tools
+- ``version``: 2.9.1-1

--- a/docs/user/components/fasterq_dump.rst
+++ b/docs/user/components/fasterq_dump.rst
@@ -28,7 +28,7 @@ Parameters
 - ``option_file``: This options enables the *option-file* parameter of
 ``fasterq-dump``, allowing parameters to be passed.
 - ``compress_fastq``: This options allows users to disable the compression of
-the fastq files resulting from this component. The default ('yes') behavior
+the fastq files resulting from this component. The default ('true') behavior
 compresses the fastq files to *fastq.gz*.
 
 Published results

--- a/docs/user/components/fasterq_dump.rst
+++ b/docs/user/components/fasterq_dump.rst
@@ -25,8 +25,11 @@ Input/Output type
 Parameters
 ----------
 
-- ``option_file``: This options enables the `option-file` parameter to
+- ``option_file``: This options enables the *option-file* parameter to
 ``fasterq-dump``, enabling to pass additional parameters to it.
+- ``compress_fastq``: This options allows users to disable the compression of
+the fastq files resulting from this component. The default ('yes') behavior
+compresses the fastq files to *fastq.gz*.
 
 Published results
 -----------------

--- a/docs/user/components/fasterq_dump.rst
+++ b/docs/user/components/fasterq_dump.rst
@@ -28,7 +28,7 @@ Parameters
 - ``option_file``: This options enables the *option-file* parameter of
 ``fasterq-dump``, allowing parameters to be passed.
 - ``compress_fastq``: This options allows users to disable the compression of
-the fastq files resulting from this component. The default ('true') behavior
+the fastq files resulting from this component. The default (``true``) behavior
 compresses the fastq files to *fastq.gz*.
 
 Published results

--- a/docs/user/components/reads_download.rst
+++ b/docs/user/components/reads_download.rst
@@ -16,8 +16,8 @@ receive FastQ data.
 Input/Output type
 ------------------
 
-- Input type: ``Accessions``
-- Output type: ``FastQ``
+- Input type: ``accessions``
+- Output type: ``fastq``
 
 .. note::
     The default input parameter for Accessions data is ``--accessions``.
@@ -44,5 +44,5 @@ Default directives
 
 - ``cpus``: 1
 - ``memory``: 1GB
-- ``container``: ummidock/getseqena
+- ``container``: flowcraft/getseqena
 - ``version``: 0.4.0-2

--- a/flowcraft/generator/components/downloads.py
+++ b/flowcraft/generator/components/downloads.py
@@ -63,6 +63,14 @@ class FasterqDump(Process):
                 "default": "false",
                 "description": "Read more options and parameters from the file."
                            "Use to provide parameters to fasterq-dump"
+            },
+            "compress_fastq": {
+                "default": "'yes'",
+                "description": "This option allow the users to define if they"
+                               "want to compress the downloaded fastq files, "
+                               "saving disk space. Default behavior is set"
+                               "to compress the fastq files. If the user wants"
+                               "to change this, set the variable to 'no'"
             }
         }
 

--- a/flowcraft/generator/components/downloads.py
+++ b/flowcraft/generator/components/downloads.py
@@ -65,7 +65,7 @@ class FasterqDump(Process):
                            "Use to provide parameters to fasterq-dump"
             },
             "compress_fastq": {
-                "default": "'yes'",
+                "default": "'true'",
                 "description": "This option allow the users to define if they"
                                "want to compress the downloaded fastq files, "
                                "saving disk space. Default behavior is set"

--- a/flowcraft/generator/components/downloads.py
+++ b/flowcraft/generator/components/downloads.py
@@ -39,3 +39,40 @@ class DownloadReads(Process):
             "container": "flowcraft/getseqena",
             "version": "0.4.0-1"
         }}
+
+
+class FasterqDump(Process):
+    """Process template for fasterq-dump
+
+    This process is set with:
+
+        - ``input_type``: accessions
+        - ``output_type`` fastq
+
+    """
+
+    def __init__(self, **kwargs):
+
+        super().__init__(**kwargs)
+
+        self.input_type = "accessions"
+        self.output_type = "fastq"
+
+        self.params = {
+            "option_file": {
+                "default": "false",
+                "description": "Read more options and parameters from the file."
+                           "Use to provide parameters to fasterq-dump"
+            }
+        }
+
+        self.directives = {"fasterqDump": {
+            "cpus": 1,
+            "memory": "'1GB'",
+            "container": "flowcraft/sra-tools",
+            "version": "2.9.1-1"
+        }}
+
+        self.status_channels = [
+            "fasterqDump"
+        ]

--- a/flowcraft/generator/components/downloads.py
+++ b/flowcraft/generator/components/downloads.py
@@ -65,7 +65,7 @@ class FasterqDump(Process):
                            "Use to provide parameters to fasterq-dump"
             },
             "compress_fastq": {
-                "default": "'true'",
+                "default": "true",
                 "description": "This option allow the users to define if they"
                                "want to compress the downloaded fastq files, "
                                "saving disk space. Default behavior is set"

--- a/flowcraft/generator/engine.py
+++ b/flowcraft/generator/engine.py
@@ -61,6 +61,7 @@ process_map = {
         "fastqc_trimmomatic": readsqc.FastqcTrimmomatic,
         "filter_poly": readsqc.FilterPoly,
         "integrity_coverage": readsqc.IntegrityCoverage,
+        "fasterq_dump": downloads.FasterqDump,
         "kraken": meta.Kraken,
         "mapping_patlas": mapping_patlas.PatlasMapping,
         "mash_dist": distest.PatlasMashDist,
@@ -1439,7 +1440,7 @@ class NextflowGenerator:
             "\tFinished configurations \u2713"))
 
         for p in self.processes:
-            self.template += p.template_str
+            self.template += "\n{}".format(p.template_str)
 
         self._build_footer()
 

--- a/flowcraft/generator/header_skeleton.py
+++ b/flowcraft/generator/header_skeleton.py
@@ -27,11 +27,14 @@ if (params.containsKey("fasta")){
     }
 }
 if (params.containsKey("accessions")){
-    BufferedReader reader = new BufferedReader(new FileReader(params.accessions));
-    int lines = 0;
-    while (reader.readLine() != null) lines++;
-    reader.close();
-    infoMap.put("accessions", lines)
+    // checks if params.accessions is different from null
+    if (params.accessions) {
+        BufferedReader reader = new BufferedReader(new FileReader(params.accessions));
+        int lines = 0;
+        while (reader.readLine() != null) lines++;
+        reader.close();
+        infoMap.put("accessions", lines)
+    }
 }
 
 Help.start_info(infoMap, "$workflow.start", "$workflow.profile")

--- a/flowcraft/generator/templates/fasterq_dump.nf
+++ b/flowcraft/generator/templates/fasterq_dump.nf
@@ -1,0 +1,43 @@
+// check if option file is provided or not
+optionFile = (params.option_file{{ param_id }} == false) ? "" :
+    "--option-file ${params.option_file{{ param_id }}}"
+
+// process to run fasterq-dump from sra-tools
+process fasterqDump_{{ pid }} {
+
+    {% include "post.txt" ignore missing %}
+
+    tag { accession_id }
+    publishDir "reads/", pattern: "${accession_id}/*fastq.gz"
+    maxRetries 1
+
+    input:
+    val accession_id from {{ input_channel }}.splitText(){ it.trim() }.filter{ it.trim() != "" }
+
+    output:
+    set accession_id, file("*fastq.gz") optional true into {{ output_channel }}
+    {% with task_name="fasterqDump", sample_id="accession_id" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
+
+    script:
+    """
+    {
+        echo "Downloading the following accession: ${accession_id}"
+        echo ${params.option_file{{ param_id }}}
+        fasterq-dump ${accession_id} -e ${task.cpus} -p ${optionFile}
+        test -f ${accession_id}_1.fastq && gzip ${accession_id}_1.fastq \
+        ${accession_id}_2.fastq || test -f ${accession_id}_3.fastq && \
+        gzip ${accession_id}_3.fastq || echo "No reads were found to compress"
+    } || {
+        # If exit code other than 0
+        if [ \$? -eq 0 ]
+        then
+            echo "pass" > .status
+        else
+            echo "fail" > .status
+            echo "Could not download accession $accession_id" > .fail
+        fi
+    }
+    """
+}

--- a/flowcraft/generator/templates/fasterq_dump.nf
+++ b/flowcraft/generator/templates/fasterq_dump.nf
@@ -26,9 +26,9 @@ process fasterqDump_{{ pid }} {
         echo "Downloading the following accession: ${accession_id}"
         echo ${params.option_file{{ param_id }}}
         fasterq-dump ${accession_id} -e ${task.cpus} -p ${optionFile}
-        test -f ${accession_id}_1.fastq && gzip ${accession_id}_1.fastq \
+        test -f ${accession_id}_1.fastq && pigz ${accession_id}_1.fastq \
         ${accession_id}_2.fastq || test -f ${accession_id}_3.fastq && \
-        gzip ${accession_id}_3.fastq || echo "No reads were found to compress"
+        pigz ${accession_id}_3.fastq || echo "No reads were found to compress"
     } || {
         # If exit code other than 0
         if [ \$? -eq 0 ]

--- a/flowcraft/generator/templates/fasterq_dump.nf
+++ b/flowcraft/generator/templates/fasterq_dump.nf
@@ -8,7 +8,7 @@ process fasterqDump_{{ pid }} {
     {% include "post.txt" ignore missing %}
 
     tag { accession_id }
-    publishDir "reads/", pattern: "${accession_id}/*fastq.gz"
+    publishDir "reads/${accession_id}/", pattern: "*fastq.gz"
     maxRetries 1
 
     input:

--- a/flowcraft/generator/templates/fasterq_dump.nf
+++ b/flowcraft/generator/templates/fasterq_dump.nf
@@ -8,14 +8,14 @@ process fasterqDump_{{ pid }} {
     {% include "post.txt" ignore missing %}
 
     tag { accession_id }
-    publishDir "reads/${accession_id}/", pattern: "*fastq.gz"
+    publishDir "reads/${accession_id}/", pattern: "*.fastq*"
     maxRetries 1
 
     input:
     val accession_id from {{ input_channel }}.splitText(){ it.trim() }.filter{ it.trim() != "" }
 
     output:
-    set accession_id, file("*fastq.gz") optional true into {{ output_channel }}
+    set accession_id, file("*.fastq*") optional true into {{ output_channel }}
     {% with task_name="fasterqDump", sample_id="accession_id" %}
     {%- include "compiler_channels.txt" ignore missing -%}
     {% endwith %}
@@ -24,11 +24,23 @@ process fasterqDump_{{ pid }} {
     """
     {
         echo "Downloading the following accession: ${accession_id}"
-        echo ${params.option_file{{ param_id }}}
         fasterq-dump ${accession_id} -e ${task.cpus} -p ${optionFile}
-        test -f ${accession_id}_1.fastq && pigz -p ${task.cpus} ${accession_id}_1.fastq \
-        ${accession_id}_2.fastq || test -f ${accession_id}_3.fastq && \
-        pigz -p ${task.cpus} ${accession_id}_3.fastq || echo "No reads were found to compress"
+        if [ ${params.compress_fastq{{ param_id }}} = "yes" ]
+        then
+            echo "Compressing FastQ files..."
+            if [ -f ${accession_id}_1.fastq ]
+            then
+                pigz -p ${task.cpus} ${accession_id}_1.fastq ${accession_id}_2.fastq
+            elif [ -f ${accession_id}_3.fastq ]
+            then
+                echo "No paired end reads were found to compress."
+                pigz -p ${task.cpus} ${accession_id}_3.fastq
+            else
+                echo "FastQ files weren't compressed. Check if any FastQ file was downloaded."
+            fi
+        else
+            echo "FastQ files won't be compressed because compress_fastq options was set to: '${params.compress_fastq{{ param_id }}}.'"
+        fi
     } || {
         # If exit code other than 0
         if [ \$? -eq 0 ]

--- a/flowcraft/generator/templates/fasterq_dump.nf
+++ b/flowcraft/generator/templates/fasterq_dump.nf
@@ -26,9 +26,9 @@ process fasterqDump_{{ pid }} {
         echo "Downloading the following accession: ${accession_id}"
         echo ${params.option_file{{ param_id }}}
         fasterq-dump ${accession_id} -e ${task.cpus} -p ${optionFile}
-        test -f ${accession_id}_1.fastq && pigz ${accession_id}_1.fastq \
+        test -f ${accession_id}_1.fastq && pigz -p ${task.cpus} ${accession_id}_1.fastq \
         ${accession_id}_2.fastq || test -f ${accession_id}_3.fastq && \
-        pigz ${accession_id}_3.fastq || echo "No reads were found to compress"
+        pigz -p ${task.cpus} ${accession_id}_3.fastq || echo "No reads were found to compress"
     } || {
         # If exit code other than 0
         if [ \$? -eq 0 ]

--- a/flowcraft/generator/templates/fasterq_dump.nf
+++ b/flowcraft/generator/templates/fasterq_dump.nf
@@ -25,7 +25,7 @@ process fasterqDump_{{ pid }} {
     {
         echo "Downloading the following accession: ${accession_id}"
         fasterq-dump ${accession_id} -e ${task.cpus} -p ${optionFile}
-        if [ ${params.compress_fastq{{ param_id }}} = "yes" ]
+        if [ ${params.compress_fastq{{ param_id }}} = "true" ]
         then
             echo "Compressing FastQ files..."
             if [ -f ${accession_id}_1.fastq ]

--- a/flowcraft/generator/templates/fasterq_dump.nf
+++ b/flowcraft/generator/templates/fasterq_dump.nf
@@ -25,7 +25,7 @@ process fasterqDump_{{ pid }} {
     {
         echo "Downloading the following accession: ${accession_id}"
         fasterq-dump ${accession_id} -e ${task.cpus} -p ${optionFile}
-        if [ ${params.compress_fastq{{ param_id }}} = "true" ]
+        if [ ${params.compress_fastq{{ param_id }}} = true ]
         then
             echo "Compressing FastQ files..."
             if [ -f ${accession_id}_1.fastq ]
@@ -36,7 +36,7 @@ process fasterqDump_{{ pid }} {
                 echo "No paired end reads were found to compress."
                 pigz -p ${task.cpus} ${accession_id}_3.fastq
             else
-                echo "FastQ files weren't compressed. Check if any FastQ file was downloaded."
+                echo "FastQ files weren't compressed. Check if FastQ files were downloaded."
             fi
         else
             echo "FastQ files won't be compressed because compress_fastq options was set to: '${params.compress_fastq{{ param_id }}}.'"

--- a/flowcraft/generator/templates/mash_screen.nf
+++ b/flowcraft/generator/templates/mash_screen.nf
@@ -1,7 +1,7 @@
 IN_reference_file_{{ pid }} = Channel.value(params.refFile{{ param_id }})
 
 // check if noWinner is provided or not
-winnerVar = (params.noWinner{{ param_id }}  == false) ? "-w" : ""
+winnerVar = (params.noWinner{{ param_id }} == false) ? "-w" : ""
 
 // process to run mashScreen and sort the output into
 // sortedMashScreenResults_{sampleId}.txt


### PR DESCRIPTION
This PR adds a new component to download reads from SRA and fixes a bug in which nf templates needed to have a blank line at the beginning of the file (now they don't need anymore).