### PR TITLE
Return params

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ to pATLAS version 1.5.2.
 
 - Added check for `params.accessions` that enables to report a proper
 error when it is set to `null`.
+- Added `build` option to export component parameters information in JSON format. 
 
 ### Bug fixes
 

--- a/flowcraft/flowcraft.py
+++ b/flowcraft/flowcraft.py
@@ -82,12 +82,19 @@ def get_args(args=None):
         "-l", "--short-list", action="store_const", dest="short_list",
         const=True, help="Print a short list of the currently "
                          "available processes")
-    build_parser.add_argument("-cr", "--check-recipe", dest="check_recipe",
-                              action="store_const", const=True,
-                              help="Check tasks that the recipe contain and "
-                                   "their flow. This option might be useful "
-                                   "if a user wants to change some components "
-                                   "of a given recipe, by using the -t option.")
+    build_parser.add_argument(
+        "-cr", "--check-recipe", dest="check_recipe",
+        action="store_const", const=True,
+        help="Check tasks that the recipe contain and "
+             "their flow. This option might be useful "
+             "if a user wants to change some components "
+             "of a given recipe, by using the -t option.")
+    build_parser.add_argument(
+        "--export-params", dest="export_params", action="store_const",
+        const=True, help="Only export the parameters for the provided "
+                         "components (via -t option) in JSON format to stdout. "
+                         "No pipeline will be generated with this option."
+    )
 
     # GENERAL OPTIONS
     parser.add_argument(
@@ -134,6 +141,18 @@ def validate_build_arguments(args):
 
     # Skip all checks when listing the processes
     if args.detailed_list or args.short_list:
+        return
+
+    # Skill all checks when exporting parameters AND providing at least one
+    # component
+    if args.export_params:
+        # Check if components provided
+        if not args.tasks:
+            logger.error(colored_print(
+                "At least one component needs to be provided via the -t option"
+                " when exporting parameters in JSON format"
+            ))
+            sys.exit(1)
         return
 
     # When none of the main run options is specified
@@ -212,6 +231,10 @@ def copy_project(path):
 
 def build(args):
 
+    # Disable standard logging for stdout when the following modes are executed:
+    if args.export_params:
+        logger.setLevel(logging.ERROR)
+
     welcome = [
         "========= F L O W C R A F T =========",
         "Build mode\n"
@@ -268,8 +291,12 @@ def build(args):
 
     logger.info(colored_print("Building your awesome pipeline..."))
 
-    # building the actual pipeline nf file
-    nfg.build()
+    if args.export_params:
+        nfg.export_params()
+        sys.exit(0)
+    else:
+        # building the actual pipeline nf file
+        nfg.build()
 
     # copy template to cwd, to allow for immediate execution
     if not args.pipeline_only:

--- a/flowcraft/flowcraft.py
+++ b/flowcraft/flowcraft.py
@@ -287,7 +287,8 @@ def build(args):
                             nextflow_file=parsed_output_nf,
                             pipeline_name=args.pipeline_name,
                             auto_dependency=args.no_dep,
-                            merge_params=args.merge_params)
+                            merge_params=args.merge_params,
+                            export_params=args.export_params)
 
     logger.info(colored_print("Building your awesome pipeline..."))
 

--- a/flowcraft/generator/engine.py
+++ b/flowcraft/generator/engine.py
@@ -107,7 +107,7 @@ class NextflowGenerator:
 
     def __init__(self, process_connections, nextflow_file,
                  pipeline_name="flowcraft", ignore_dependencies=False,
-                 auto_dependency=True, merge_params=True):
+                 auto_dependency=True, merge_params=True, export_params=False):
 
         self.processes = []
 
@@ -1404,6 +1404,22 @@ class NextflowGenerator:
         pipeline_to_json = self.render_pipeline()
         with open(splitext(self.nf_file)[0] + ".html", "w") as fh:
             fh.write(pipeline_to_json)
+
+    def export_params(self):
+        """Export pipeline params as a JSON to stdout
+
+        This run mode iterates over the pipeline processes and exports the
+        params dictionary of each component as a JSON to stdout.
+        """
+
+        params_json = {}
+
+        # Skip first init process
+        for p in self.processes[1:]:
+            params_json[p.template] = p.params
+
+        # Flush params json to stdout
+        sys.stdout.write(json.dumps(params_json))
 
     def build(self):
         """Main pipeline builder

--- a/flowcraft/generator/engine.py
+++ b/flowcraft/generator/engine.py
@@ -134,11 +134,22 @@ class NextflowGenerator:
         int: Stores the number of lanes in the pipelines
         """
 
+        self.export_parameters = export_params
+        """
+        bool: Determines whether the build mode is only for the export of 
+        parameters in JSON format. Setting to True will disabled some checks,
+        such as component dependency requirements
+        """
+
+        # When the export_params option is used, disable the auto dependency
+        # feature automatically
+        auto_deps = auto_dependency if not self.export_parameters else False
+
         # Builds the connections in the processes, which parses the
         # process_connections dictionary into the self.processes attribute
         # list.
         self._build_connections(process_connections, ignore_dependencies,
-                                auto_dependency)
+                                auto_deps)
 
         self.nf_file = nextflow_file
         """
@@ -409,7 +420,7 @@ class NextflowGenerator:
                         if auto_dependency:
                             self._add_dependency(
                                 out_process, dep, in_lane, out_lane, p)
-                        else:
+                        elif not self.export_parameters:
                             logger.error(colored_print(
                                 "\nThe following dependency of the process"
                                 " '{}' is missing: {}".format(p_out_name, dep),


### PR DESCRIPTION
This PR adds a new option ``--export-params`` to the `build`mode. This returns a JSON with the parameters for the provided components (via the ``-t option``) to the standard output.