### PR TITLE
Assembly graph results

### DIFF
--- a/flowcraft/generator/components/metagenomics.py
+++ b/flowcraft/generator/components/metagenomics.py
@@ -139,6 +139,12 @@ class Megahit(Process):
                     "'default', megahit will use the default k-mer lengths. "
                     "(default: $params.megahitKmers)"
             },
+            "fastg": {
+                "default": "false",
+                "description":
+                    "Converts megahit intermediate contigs to fastg"
+
+            },
             "clearInput": {
                 "default": "false",
                 "description":

--- a/flowcraft/generator/components/metagenomics.py
+++ b/flowcraft/generator/components/metagenomics.py
@@ -155,7 +155,17 @@ class Megahit(Process):
             "container": "flowcraft/megahit",
             "version": "1.1.3-0.1",
             "scratch": "true"
-        }}
+        },
+            "megahit_fastg": {
+                "container": "flowcraft/megahit",
+                "version": "1.1.3-0.1",
+            }
+        }
+
+        self.status_channels = [
+            "megahit",
+            "megahit_fastg"
+        ]
 
 
 class Metaspades(Process):

--- a/flowcraft/generator/templates/megahit.nf
+++ b/flowcraft/generator/templates/megahit.nf
@@ -23,7 +23,7 @@ process megahit_{{ pid }} {
 
     output:
     set sample_id, file('*megahit*.fasta') into {{ output_channel }}
-    set sample_id, file('megahit/intermediate_contigs/k*.contigs.fa') into toValidate_{{ pid }}
+    set sample_id, file('megahit/intermediate_contigs/k*.contigs.fa') into IN_fastg{{ pid }}
     {% with task_name="megahit" %}
     {%- include "compiler_channels.txt" ignore missing -%}
     {% endwith %}
@@ -36,38 +36,34 @@ IN_fastg = Channel.create()
 
 fastg = params.fastg{{ param_id }} ? "true" : "false"
 if (fastg) {
-    toValidate_{{ pid }}.set{IN_fastg}
-}
+    process megahit_fastg_{{ pid }}{
 
-process megahit_fastg_{{ pid }}{
+        // Send POST request to platform
+        {% include "post.txt" ignore missing %}
 
-    // Send POST request to platform
-    {% include "post.txt" ignore missing %}
+        tag { sample_id }
+        publishDir "results/assembly/megahit_{{ pid }}/$sample_id", pattern: "*.fastg"
 
-    tag { sample_id }
-    publishDir "results/assembly/megahit_{{ pid }}/$sample_id", pattern: "*.fastg"
+        input:
+        set sample_id, file(kmer_files) from IN_fastg{{ pid }}
 
-    input:
-    set sample_id, file(kmer_files) from IN_fastg
+        output:
+        file "*.fastg"
+        {% with task_name="megahit_fastg" %}
+        {%- include "compiler_channels.txt" ignore missing -%}
+        {% endwith %}
 
-    output:
-    file "*.fastg"
-    {% with task_name="megahit_fastg" %}
-    {%- include "compiler_channels.txt" ignore missing -%}
-    {% endwith %}
-
-    script:
-    """
-    for kmer_file in ${kmer_files};
-    do
-        echo \$kmer_file
-        k=\$(echo \$kmer_file | cut -d '.' -f 1);
-        echo \$k
-        megahit_toolkit contig2fastg \$k \$kmer_file > \$kmer_file'.fastg';
-    done
-    """
-
-
+        script:
+        """
+        for kmer_file in ${kmer_files};
+        do
+            echo \$kmer_file
+            k=\$(echo \$kmer_file | cut -d '.' -f 1);
+            echo \$k
+            megahit_toolkit contig2fastg \$k \$kmer_file > \$kmer_file'.fastg';
+        done
+        """
+    }
 }
 
 {{ forks }}

--- a/flowcraft/generator/templates/spades.nf
+++ b/flowcraft/generator/templates/spades.nf
@@ -24,6 +24,8 @@ process spades_{{ pid }} {
 
     tag { sample_id }
     publishDir 'results/assembly/spades_{{ pid }}/', pattern: '*_spades*.fasta', mode: 'copy'
+    publishDir "reports/assembly/spades_{{ pid }}/$sample_id", pattern: "*.gfa", mode: "copy"
+    publishDir "reports/assembly/spades_{{ pid }}/$sample_id", pattern: "*.fastg", mode: "copy"
 
     input:
     set sample_id, file(fastq_pair), max_len from {{ input_channel }}.join(SIDE_max_len_{{ pid }})
@@ -33,6 +35,8 @@ process spades_{{ pid }} {
 
     output:
     set sample_id, file('*_spades*.fasta') into {{ output_channel }}
+    file "*.fastg"
+    file "*.gfa"
     {% with task_name="spades" %}
     {%- include "compiler_channels.txt" ignore missing -%}
     {% endwith %}


### PR DESCRIPTION
This PR adds the publishing of assembly graph results for assemblers that support this format:

- [x] spades
- [x] megahit

The results are are published under:

```
reports/assembly/spades_<pid>/<sample_id>
reports/assembly/megahit_<pid>/<sample_id>
```