### PR TITLE
Added default docker option to avoid docker permission errors.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 - Added removal of duplicate IDs from `reads_download` component input.
 - Added seed parameter to `downsample_fastq` component.
+- Added default docker option to avoid docker permission errors.
 
 ### Bug fixes
 

--- a/flowcraft/nextflow.config
+++ b/flowcraft/nextflow.config
@@ -32,6 +32,13 @@ process {
     container = "flowcraft/flowcraft_base:1.0.0-1"
 }
 
+docker {
+    // Added default docker option to avoid docker permission errors. See issue
+    // #142
+    runOptions = "-u \$(id -u):\$(id -g)"
+}
+
+
 executor {
   $local {
       cpus = 4


### PR DESCRIPTION
Added new default option for docker engine:

```
docker {
    runOptions = "-u \$(id -u):\$(id -g)"
}
```

This option prevents permission issues when running docker containers on certain machines. I've tested this option in several machines with docker and this new default does not change the execution of systems that ran without it before. 