### PR TITLE
added timestamp to report and inspect

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,7 @@ resolution
 
 - Fixed forks with same source process name.
 - Fixed `inspect` issue when tasks took more than a day in duration.
+- Added timestamp to `inpsect` and `report` hash.
 
 ## 1.3.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -37,7 +37,7 @@ resolution
 
 - Fixed forks with same source process name.
 - Fixed `inspect` issue when tasks took more than a day in duration.
-- Added timestamp to `inpsect` and `report` hash.
+- Added hardware address to `inpsect` and `report` hash.
 
 ## 1.3.1
 

--- a/flowcraft/generator/inspect.py
+++ b/flowcraft/generator/inspect.py
@@ -1540,7 +1540,8 @@ class NextflowInspector:
         # Get hash from the current working dir and hostname
         workdir = self.workdir.encode("utf8")
         hostname = socket.gethostname().encode("utf8")
-        dir_hash = hashlib.md5(workdir + hostname)
+        timestamp = str(time.time()).encode("utf8")
+        dir_hash = hashlib.md5(workdir + hostname + timestamp)
 
         return pipeline_hash.hexdigest() + dir_hash.hexdigest()
 

--- a/flowcraft/generator/inspect.py
+++ b/flowcraft/generator/inspect.py
@@ -1,6 +1,7 @@
 import re
 import os
 import sys
+import uuid
 import time
 import curses
 import signal
@@ -1540,8 +1541,8 @@ class NextflowInspector:
         # Get hash from the current working dir and hostname
         workdir = self.workdir.encode("utf8")
         hostname = socket.gethostname().encode("utf8")
-        timestamp = str(time.time()).encode("utf8")
-        dir_hash = hashlib.md5(workdir + hostname + timestamp)
+        hardware_addr = str(uuid.getnode()).encode("utf8")
+        dir_hash = hashlib.md5(workdir + hostname + hardware_addr)
 
         return pipeline_hash.hexdigest() + dir_hash.hexdigest()
 

--- a/flowcraft/generator/report.py
+++ b/flowcraft/generator/report.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 import json
+import time
 import signal
 import socket
 import hashlib
@@ -195,7 +196,8 @@ class FlowcraftReport:
             # Get hash from the current working dir and hostname
             workdir = os.getcwd().encode("utf8")
             hostname = socket.gethostname().encode("utf8")
-            dir_hash = hashlib.md5(workdir + hostname)
+            timestamp = str(time.time()).encode("utf8")
+            dir_hash = hashlib.md5(workdir + hostname + timestamp)
 
             return pipeline_hash.hexdigest() + dir_hash.hexdigest()
 

--- a/flowcraft/generator/report.py
+++ b/flowcraft/generator/report.py
@@ -2,7 +2,7 @@ import os
 import re
 import sys
 import json
-import time
+import uuid
 import signal
 import socket
 import hashlib
@@ -196,8 +196,8 @@ class FlowcraftReport:
             # Get hash from the current working dir and hostname
             workdir = os.getcwd().encode("utf8")
             hostname = socket.gethostname().encode("utf8")
-            timestamp = str(time.time()).encode("utf8")
-            dir_hash = hashlib.md5(workdir + hostname + timestamp)
+            hardware_addr = str(uuid.getnode()).encode("utf8")
+            dir_hash = hashlib.md5(workdir + hostname + hardware_addr)
 
             return pipeline_hash.hexdigest() + dir_hash.hexdigest()
 


### PR DESCRIPTION
This PR solves the issue when several cloned instances of the same machine (for instance a vm) are sending the same pipeline to the flowcraft-webapp service.