### PR TITLE
set treeDag and forkTrre files paths from relative to absolute

### DIFF
--- a/flowcraft/generator/templates/Helper.groovy
+++ b/flowcraft/generator/templates/Helper.groovy
@@ -65,8 +65,8 @@ class CollectInitialMetadata {
 
     public static void print_metadata(nextflow.script.WorkflowMetadata workflow){
 
-        def treeDag = new File(".treeDag.json").text
-        def forkTree = new File(".forkTree.json").text
+        def treeDag = new File("${workflow.projectDir}/.treeDag.json").text
+        def forkTree = new File("${workflow.projectDir}/.forkTree.json").text
 
         def metadataJson = "{'nfMetadata':{'scriptId':'${workflow.scriptId}',\
 'scriptName':'${workflow.scriptName}',\

--- a/flowcraft/generator/templates/report_compiler.nf
+++ b/flowcraft/generator/templates/report_compiler.nf
@@ -35,8 +35,8 @@ process compile_reports {
 
     input:
     file report from master_report.collect()
-    file forks from Channel.fromPath(".forkTree.json")
-    file dag from Channel.fromPath(".treeDag.json")
+    file forks from Channel.fromPath("${workflow.projectDir}/.forkTree.json")
+    file dag from Channel.fromPath("${workflow.projectDir}/.treeDag.json")
     file js from Channel.fromPath("${workflow.projectDir}/resources/main.js.zip")
 
     output:


### PR DESCRIPTION
This PR allows running flowcraft generated pipelines independently on the CWD, by setting the treeDag and forkTree location dependent on the projectDir