### PR TITLE
fix flowcraft report nf file path retrieval. 

### DIFF
--- a/flowcraft/generator/report.py
+++ b/flowcraft/generator/report.py
@@ -185,8 +185,7 @@ class FlowcraftReport:
             with open(self.log_file) as fh:
                 header = fh.readline()
 
-            pipeline_path = re.match(
-                ".*nextflow run ([^\s]+).*", header).group(1)
+            pipeline_path = re.match(".*\s([/\w/]*\w*.nf).*", header).group(1)
 
             # Get hash from the entire pipeline file
             pipeline_hash = hashlib.md5()


### PR DESCRIPTION
This pull request fixes the retrieval of the pipeline path based on the nexflow.log file.
It can now be at different positions of the nexflow run command but It expects the file extension to be .nf