### PR TITLE
Fix search for nextflow run command in .nextflow.log

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@
 - Fix bug in `momps`component related to added in the introduction of the clear input parameter
 - Fixed bug with the `-ft` parameters not retrieving the dockerhub tags for 
 all the components.
+- Fix inspect and report mode to fetch the nextflow file independently of its 
+position in the `nextflow run` command inside the .nextflow.log file.
+- Fix parsing of .nextflow.log file when searching for `nextflow run` command.
+
 
 ### Minor/Other changes
 

--- a/flowcraft/generator/inspect.py
+++ b/flowcraft/generator/inspect.py
@@ -1530,10 +1530,19 @@ class NextflowInspector:
 
         # Get name of the pipeline from the log file
         with open(self.log_file) as fh:
-            header = fh.readline()
-
-        # Regex supports absolute paths and relative paths
-        pipeline_path = re.match(".*\s([/\w/]*\w*.nf).*", header).group(1)
+            # Searches for the first occurence of the nextflow pipeline
+            # file name in the .nextflow.log file
+            while 1:
+                line = fh.readline()
+                if not line:
+                    break
+                try:
+                    # Regex supports absolute paths and relative paths
+                    pipeline_path = re.match(".*\s([/\w/]*\w*.nf).*", line) \
+                        .group(1)
+                    break
+                except AttributeError:
+                    continue
 
         # Get hash from the entire pipeline file
         pipeline_hash = hashlib.md5()

--- a/flowcraft/generator/report.py
+++ b/flowcraft/generator/report.py
@@ -183,9 +183,19 @@ class FlowcraftReport:
         if self.watch:
 
             with open(self.log_file) as fh:
-                header = fh.readline()
 
-            pipeline_path = re.match(".*\s([/\w/]*\w*.nf).*", header).group(1)
+                # Searches for the first occurence of the nextflow pipeline
+                # file name in the .nextflow.log file
+                while 1:
+                    line = fh.readline()
+                    if not line:
+                        break
+                    try:
+                        pipeline_path = re.match(".*\s([/\w/]*\w*.nf).*", line)\
+                            .group(1)
+                        break
+                    except AttributeError:
+                        continue
 
             # Get hash from the entire pipeline file
             pipeline_hash = hashlib.md5()


### PR DESCRIPTION
This PR fixes the issue when inspect and report modes fail to retrieve nextflow run command from the .nextflow.log file when it is not on the first line.