### PR TITLE
momps and mlst: remove collect from report to avoid overwriting previous results when a pipeline is resumed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,8 @@ all the components.
 position in the `nextflow run` command inside the .nextflow.log file.
 - Fix parsing of .nextflow.log file when searching for `nextflow run` command.
 - Fixed bug between mash_sketch_fasta and mash_dist.
+- `momps` and `mlst` components now save results per sample to avoid overwriting
+results from previous runs
 
 ### Minor/Other changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@ with a secondary channel into `mafft`
 - New version of DEN-IM recipe
 - Now prints an ordered list of components
 - Moved taxonomy results from `results/annotation/` to `results/taxonomy/`
+- Moved mlst results from `results/annotation/` to `results/typing/`
 
 
 ## 1.4.0

--- a/flowcraft/generator/templates/mlst.nf
+++ b/flowcraft/generator/templates/mlst.nf
@@ -12,7 +12,7 @@ process mlst_{{ pid }} {
     set sample_id, file(assembly) from {{ input_channel }}
 
     output:
-    file '*.mlst.txt' into LOG_mlst_{{ pid }}
+    set sample_id, file('*.mlst.txt') into LOG_mlst_{{ pid }}
     set sample_id, file(assembly), file(".status") into MAIN_mlst_out_{{ pid }}
     {% with task_name="mlst" %}
     {%- include "compiler_channels.txt" ignore missing -%}
@@ -47,17 +47,17 @@ process mlst_{{ pid }} {
 
 process compile_mlst_{{ pid }} {
 
-    publishDir "results/annotation/mlst_{{ pid }}/"
+    publishDir "results/typing/mlst_{{ pid }}/"
 
     input:
-    file res from LOG_mlst_{{ pid }}.collect()
+    set sample_id, res from LOG_mlst_{{ pid }}
 
     output:
-    file "mlst_report.tsv"
+    file "*mlst_report.tsv"
 
     script:
     """
-    cat $res >> mlst_report.tsv
+    cat $res > ${sample_id}_mlst_report.tsv
     """
 }
 

--- a/flowcraft/generator/templates/momps.nf
+++ b/flowcraft/generator/templates/momps.nf
@@ -14,6 +14,7 @@ process momps_{{ pid }} {
     val clear from checkpointClear_{{ pid }}
 
     output:
+    val sample_id into momps_sample_id_{{ pid }}
     file("*_st.tsv") into momps_st_{{ pid }}
     file("*_profile.tsv") into momps_profile_{{ pid }}
     {% with task_name="momps" %}
@@ -75,8 +76,9 @@ process momps_report_{{ pid }} {
     publishDir "results/typing/momps_{{ pid }}/", pattern: "*.tsv"
 
     input:
-    file(st_file) from momps_st_{{ pid }}.collect()
-    file(profile_file) from momps_profile_{{ pid }}.collect()
+    val sample_id from momps_sample_id_{{ pid }}
+    file(st_file) from momps_st_{{ pid }}
+    file(profile_file) from momps_profile_{{ pid }}
 
     output:
     file "*.tsv"
@@ -84,8 +86,8 @@ process momps_report_{{ pid }} {
 
     script:
     """
-    cat $st_file >> momps_st.tsv
-    cat $profile_file >> momps_profile.tsv
+    cat $st_file > ${sample_id}_momps_st.tsv
+    cat $profile_file > ${sample_id}_momps_profile.tsv
     """
 
 }


### PR DESCRIPTION
As explained in the issue #195, the compilation of the momps and mlst results into a single file causes for previous results to be overwritten when a pipeline is resumed. To avoid this situation, now the results are saved in a file per sample. After pipeline completion it's easy enough to obtain a single file with all the results for these components by concatenating all files together. 