### PR TITLE
Update utils.py - fix regex

### DIFF
--- a/flowcraft/generator/utils.py
+++ b/flowcraft/generator/utils.py
@@ -32,7 +32,7 @@ def get_nextflow_filepath(log_file):
                                  ".nextflow.log empty?")
             try:
                 # Regex supports absolute paths and relative paths
-                pipeline_path = re.match(".*\s([/\w/]*\w*.nf).*", line) \
+                pipeline_path = re.match(".*\s(.*.nf).*", line) \
                     .group(1)
                 return pipeline_path
             except AttributeError:

--- a/flowcraft/tests/broadcast_tests/log_with_command_regex.txt
+++ b/flowcraft/tests/broadcast_tests/log_with_command_regex.txt
@@ -1,0 +1,2 @@
+Log with command - different chars in path
+/usr/local/bin/nextflow run /mnt/innuendo_storage/users/bgoncalves/jobs/2-3/test.nf -profile incd -resume

--- a/flowcraft/tests/test_broadcast.py
+++ b/flowcraft/tests/test_broadcast.py
@@ -23,3 +23,9 @@ def test_path_in_log():
 
     assert filepath != ""
 
+def test_regex_in_log():
+    filepath = utils.get_nextflow_filepath(
+        os.path.join(os.getcwd(), "flowcraft/tests/broadcast_tests/log_with_command_regex.txt"))
+
+    assert filepath != ""
+


### PR DESCRIPTION
With the \w* hyphens were not included, so the inspect breaks when the paths or the nf file contained this character as it could not correctly parse the .nextflow.log. Altered this to .* to allow any character.