### PR TITLE
remove optional true

### DIFF
--- a/flowcraft/generator/templates/reads_download.nf
+++ b/flowcraft/generator/templates/reads_download.nf
@@ -21,7 +21,7 @@ process reads_download_{{ pid }} {
     each file(aspera_key) from IN_asperaKey_{{ pid }}
 
     output:
-    set val({ "$name" != "null" ? "$name" : "$accession_id" }), file("${accession_id}/*fq.gz") optional true into {{ output_channel }}
+    set val({ "$name" != "null" ? "$name" : "$accession_id" }), file("${accession_id}/*fq.gz") into {{ output_channel }}
     {% with task_name="reads_download", sample_id="accession_id" %}
     {%- include "compiler_channels.txt" ignore missing -%}
     {% endwith %}


### PR DESCRIPTION
With the "optional true" in the output field, this process will never fail. If the download (for whatever reason) fails, the user should know :P 

I don't know if there was any reason to add that optional true, if there was, please comment here! 